### PR TITLE
Optionally use DOMContentLoaded rather than load event as our minumim

### DIFF
--- a/boomerang.js
+++ b/boomerang.js
@@ -2348,7 +2348,8 @@ BOOMR_check_doc_domain();
 				    "beacon_type",
 				    "site_domain",
 				    "strip_query_string",
-				    "user_ip"
+						"user_ip",
+						"useDOMContentLoaded"
 			    ];
 
 			/* BEGIN_DEBUG */
@@ -2586,7 +2587,7 @@ BOOMR_check_doc_domain();
 					BOOMR.utils.addListener(w, "pageshow", cb);
 				}
 				else {
-					BOOMR.utils.addListener(w, "load", cb);
+					BOOMR.utils.addListener(w, BOOMR.getLoadEvent(), cb);
 				}
 			}
 		},
@@ -2694,6 +2695,12 @@ BOOMR_check_doc_domain();
 			// doesn't fire a second `pageshow` event in some browsers (e.g. Safari). We need to check if
 			// `performance.timing.loadEventStart` or `BOOMR_onload` has occurred to detect this scenario. Will not work for
 			// older Safari that doesn't have NavTiming
+
+			if (BOOMR.getLoadEvent() === "DOMContentLoaded") {
+				return (d.readyState && (d.readyState === "complete" || d.readyState === "interactive")) || (p && p.timing && p.timing.domContentLoadedEventStart > 0) ||
+				w.BOOMR_onload > 0;
+			}
+
 			return ((d.readyState && d.readyState === "complete") ||
 			    (p && p.timing && p.timing.loadEventStart > 0) ||
 			    w.BOOMR_onload > 0);
@@ -3248,6 +3255,10 @@ BOOMR_check_doc_domain();
 		 */
 		getVar: function(name) {
 			return impl.vars[name];
+		},
+
+		getLoadEvent: function() {
+			return impl.useDOMContentLoaded ? "DOMContentLoaded" : 'load'
 		},
 
 		/**

--- a/boomerang.js
+++ b/boomerang.js
@@ -2350,7 +2350,10 @@ BOOMR_check_doc_domain();
 				    "strip_query_string",
 						"user_ip",
 						"useDOMContentLoaded"
-			    ];
+					];
+
+			// NOTE that useDOMContentLoaded is needed in other plugins so set it first
+			impl.useDOMContentLoaded= config.useDOMContentLoaded;
 
 			/* BEGIN_DEBUG */
 			BOOMR.utils.mark("init");

--- a/plugins/auto-xhr.js
+++ b/plugins/auto-xhr.js
@@ -827,7 +827,7 @@
 		if (resource.initiator === "spa_hard") {
 			// don't wait for onload if this was an aborted SPA navigation
 			if ((!ev || !ev.aborted) && !BOOMR.hasBrowserOnloadFired()) {
-				BOOMR.utils.addListener(w, "load", function() {
+				BOOMR.utils.addListener(w, BOOMR.getLoadEvent(), function() {
 					var loadTimestamp = BOOMR.now();
 
 					// run after the 'load' event handlers so loadEventEnd is captured

--- a/plugins/history.js
+++ b/plugins/history.js
@@ -338,7 +338,7 @@
 		}
 		else {
 			// the event listener will be registered early enough to get an unwanted event if we don't use setTimeout
-			BOOMR.window.addEventListener("load", function() { setTimeout(aelPopstate, 0); });
+			BOOMR.window.addEventListener(BOOMR.getLoadEvent(), function() { setTimeout(aelPopstate, 0); });
 		}
 
 		// listen for a beacon

--- a/plugins/rt.js
+++ b/plugins/rt.js
@@ -777,11 +777,10 @@
 				// use loadEventEnd from NavigationTiming
 				p = BOOMR.getPerformance();
 
-				// We have navigation timing,
 				if (p && p.timing) {
-					// and the loadEventEnd timestamp
-					if (p.timing.loadEventEnd) {
-						return p.timing.loadEventEnd;
+					var potentialEndDate = BOOMR.getLoadEvent() ? p.timing.domContentLoadedEventEnd : p.timing.loadEventEnd;
+					if (potentialEndDate) {
+						return potentialEndDate;
 					}
 				}
 				// We don't have navigation timing,

--- a/plugins/spa.js
+++ b/plugins/spa.js
@@ -171,8 +171,9 @@
 				// No other resources were fetched, so set the end time
 				// to NavigationTiming's performance.loadEventEnd if available (instead of 'now')
 				p = BOOMR.getPerformance();
-				if (p && p.timing && p.timing.navigationStart && p.timing.loadEventEnd) {
-					resource.timing.loadEventEnd = p.timing.loadEventEnd;
+				var potentialEndDate = BOOMR.getLoadEvent() ? p.timing.domContentLoadedEventEnd : p.timing.loadEventEnd;
+				if (potentialEndDate) {
+					resource.timing.loadEventEnd = potentialEndDate;
 				}
 			}
 		},
@@ -263,7 +264,7 @@
 				return;
 			}
 
-			if (autoXhrEnabled) {	
+			if (autoXhrEnabled) {
 				// re-enable AutoXHR if it's enabled
 				BOOMR.plugins.AutoXHR.enableAutoXhr();
 			}


### PR DESCRIPTION
By default the load event defines the minimum time our `spa_hard` fires. We have some use cases where we are downloading scripts that don't block the page being usable. Thus we want the option to use `DOMContentLoaded` instead 