### PR TITLE
Add resources to spa beacon

### DIFF
--- a/plugins/auto-xhr.js
+++ b/plugins/auto-xhr.js
@@ -814,6 +814,9 @@
 
 					impl.addedVars.push("pgu", "rt.quit", "rt.abld");
 				}
+
+				BOOMR.addVar('resources', resource.resources, true);
+				BOOMR.addVar('xhrResources', resource.xhrResources, true);
 			}
 
 			BOOMR.responseEnd(resource, startTime, resource);


### PR DESCRIPTION
- To help debug an issue where it's not clear why a spa is taking so long. This should show what resources we were waiting on