### PR TITLE
Fix edge cases where existingResource endTime not recorded correctly

### DIFF
--- a/boomerang.js
+++ b/boomerang.js
@@ -3584,6 +3584,10 @@ BOOMR_check_doc_domain();
 				return false;
 			}
 
+			if (impl.vars['http.initiator'] === 'spa_hard') {
+				BOOMR.appendVar('beacon_attempts', performance.now());
+			}
+
 			/* BEGIN_DEBUG */
 			BOOMR.utils.mark("send_beacon:start");
 			/* END_DEBUG */
@@ -3602,6 +3606,7 @@ BOOMR_check_doc_domain();
 					}
 					if (!this.plugins[k].is_complete(impl.vars)) {
 						BOOMR.debug("Plugin " + k + " is not complete, deferring beacon send");
+						BOOMR.appendVar('beacon_defer', k);
 						return false;
 					}
 				}

--- a/plugins/auto-xhr.js
+++ b/plugins/auto-xhr.js
@@ -962,7 +962,6 @@
 		if (!timeout) {
 			return;
 		}
-		console.log("Setting time out", timeout);
 
 		this.clearTimeout(index);
 
@@ -1107,8 +1106,6 @@
 		}
 
 		current_event.nodes_to_wait--;
-
-		console.log("Firing load finished", current_event)
 
 		if (current_event.nodes_to_wait === 0) {
 			// mark the end timestamp with what was given to us, or, now
@@ -1932,7 +1929,6 @@
 			}
 		};
 
-		console.log("Overwiring native fetch");
 		// Overwrite window.fetch, ensuring the original is swapped back in
 		// if the Boomerang IFRAME is unloaded.  uninstrumentFetch() may also
 		// be used to swap the original back in.
@@ -2411,7 +2407,6 @@
 				handler.monitorMO(resource.index);
 
 				// fire the load_finished handler for the corresponding event.
-
 				handler.load_finished(resource.index, resource.timing.responseEnd);
 			}
 		}

--- a/plugins/spa.js
+++ b/plugins/spa.js
@@ -178,6 +178,7 @@
 					potentialEndDate = impl.minEndTime;
 				}
 				if (potentialEndDate) {
+					resource.spaMinEndDate = potentialEndDate;
 					resource.timing.loadEventEnd = potentialEndDate;
 					BOOMR.addVar("t_min_init", potentialEndDate);
 				}


### PR DESCRIPTION
- https://github.com/zenefits/boomerang/compare/master-zenefits...zenefits:gc/existing-resource-edge-cases?expand=1#diff-151035926508d5aa70a3600926d73cd2R1384 fixes edge case where it's possible that we don't consider the end of a fetch if boomerang is initialized after the fetch starts and right before it ends
- Adds a couple debug params. Trying to debug why I see some hardNavigations which are too high:
  - Log when we attempt to send a beacon
  - Log when a plugin blocks the sending of a beacon